### PR TITLE
feat(ui): print media size in media viewer

### DIFF
--- a/src/rs/ncube-data/src/lib.rs
+++ b/src/rs/ncube-data/src/lib.rs
@@ -774,6 +774,11 @@ pub struct ClientSubscription {
     pub url: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct FileMetadata {
+    pub size_in_bytes: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/rs/ncube-http-api/src/unit.rs
+++ b/src/rs/ncube-http-api/src/unit.rs
@@ -84,6 +84,22 @@ async fn download(
 }
 
 #[instrument]
+async fn download_metadata(
+    _ctx: ReqCtx,
+    workspace: String,
+    unit_id: String,
+    kind: String,
+    file: String,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let file_path = format!("{}/{}/{}", &unit_id, &kind, &file);
+    let data = handlers::show_download_meta(&workspace, &file_path).await?;
+
+    let response = SuccessResponse::new(data);
+
+    Ok(warp::reply::json(&response))
+}
+
+#[instrument]
 async fn show(
     _ctx: ReqCtx,
     workspace: String,
@@ -134,4 +150,10 @@ pub(crate) fn routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::
             .and(warp::get())
             .and(conditionals())
             .and_then(download))
+        .or(authenticate_remote_req()
+            .and(warp::path!(
+                "workspaces" / String / "data" / String / String / String / "meta"
+            ))
+            .and(warp::get())
+            .and_then(download_metadata))
 }

--- a/src/ts/components/file-meta.tsx
+++ b/src/ts/components/file-meta.tsx
@@ -1,0 +1,29 @@
+import Humanize from "humanize-plus";
+import React, {useEffect, useState} from "react";
+
+import {showFileMeta} from "../lib/http";
+import {FileMetadata} from "../types";
+
+interface FileMetaProps {
+  workspace: string;
+  location: string;
+}
+
+const FileMeta = ({workspace, location}: FileMetaProps) => {
+  const [fileMeta, setFileMeta] = useState<FileMetadata>();
+  useEffect(() => {
+    const f = async () => {
+      const data = await showFileMeta(workspace, location);
+      setFileMeta(data);
+    };
+    f();
+  }, [workspace, location]);
+
+  if (!fileMeta) return <div />;
+
+  return (
+    <span className="text-sm">{Humanize.fileSize(fileMeta.size_in_bytes)}</span>
+  );
+};
+
+export default FileMeta;

--- a/src/ts/components/media-viewer.tsx
+++ b/src/ts/components/media-viewer.tsx
@@ -11,6 +11,7 @@ import chevronLeft from "../svg/chevron_left.svg";
 import chevronRight from "../svg/chevron_right.svg";
 import {Download} from "../types";
 import ButtonDownload from "./button-download";
+import FileMeta from "./file-meta";
 import ImageViewer from "./image-viewer";
 import VideoPlayer from "./video-player";
 
@@ -110,11 +111,12 @@ const MediaViewer = ({downloads}: MediaViewerProps) => {
 
             return (
               <SwiperSlide key={idHash}>
-                <ButtonDownload
-                  className="ml-auto"
-                  onClick={handleClick}
-                  label="Download Media"
-                />
+                <div className="flex items-center justify-end">
+                  {location && (
+                    <FileMeta workspace={slug} location={location} />
+                  )}
+                  <ButtonDownload onClick={handleClick} />
+                </div>
                 <MediaSlide key={idHash} url={url} type={type} />
               </SwiperSlide>
             );

--- a/src/ts/lib/http.ts
+++ b/src/ts/lib/http.ts
@@ -3,6 +3,7 @@ import {EventObject, State} from "xstate";
 import {
   Annotation,
   ConfigSettingReq,
+  FileMetadata,
   HostConfig,
   Investigation,
   InvestigationReq,
@@ -321,6 +322,19 @@ export const showUnit = async (
 ): Promise<Unit> => {
   const url = new URL(
     `http://127.0.0.1:40666/api/workspaces/${workspace}/data/units/${id}`,
+  );
+
+  const resp = await fetch(url.toString());
+
+  return dataResponse(resp);
+};
+
+export const showFileMeta = async (
+  workspace: string,
+  location: string,
+): Promise<FileMetadata> => {
+  const url = new URL(
+    `http://127.0.0.1:40666/api/workspaces/${workspace}/${location}/meta`,
   );
 
   const resp = await fetch(url.toString());

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -289,6 +289,10 @@ export type ProcessRunReq = {
   kind: "all" | "new" | "selection";
 };
 
+export type FileMetadata = {
+  size_in_bytes: number;
+};
+
 /*
  * The request types represent request objects to the HTTP API. They are usually
  * used in the `./http/*` functions. Additionally to types I run validations for


### PR DESCRIPTION
There will be more things I would like to show as media meta data. File
size is a good start. In the future I probably will want to add
MD5/SHA256 hashes, fetch dates, etc ...